### PR TITLE
implement adoption procedure related services and APIs

### DIFF
--- a/src/main/java/furiends/backend/controller/OrganizationController.java
+++ b/src/main/java/furiends/backend/controller/OrganizationController.java
@@ -1,5 +1,7 @@
 package furiends.backend.controller;
 
+import furiends.backend.dto.AdoptionProcedure;
+import furiends.backend.dto.AdoptionProcedureStep;
 import furiends.backend.dto.OrganizationRequest;
 import furiends.backend.model.Organization;
 import furiends.backend.service.OrganizationService;
@@ -13,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.Optional;
 
-@RestController()
+@RestController
 @RequestMapping(path = "api/v1/organizations")
 public class OrganizationController {
     private static final Logger logger = LogManager.getLogger(OrganizationController.class);
@@ -68,6 +70,31 @@ public class OrganizationController {
     public ResponseEntity deleteOrganization(@PathVariable String id) {
         try {
             organizationService.deleteOrganization(id);
+        } catch (Exception e) {
+            logger.error(e.toString());
+            return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return new ResponseEntity(HttpStatus.OK);
+    }
+
+    // get adoption procedure by organization id
+    @GetMapping("{id}/adoptionProcedure")
+    public ResponseEntity<List<AdoptionProcedureStep>> getOrganizationAdoptionProcedure(@PathVariable("id") String id) {
+        List<AdoptionProcedureStep> adoptionProcedureStepList;
+        try {
+            adoptionProcedureStepList = organizationService.listAdoptionProcedureSteps(id);
+        } catch (Exception e) {
+            logger.error(e.toString());
+            return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return ResponseEntity.ok(adoptionProcedureStepList);
+    }
+
+    // update all adoption procedure by organization id (create and delete operations can also use this API to update)
+    @PostMapping("{id}/adoptionProcedure")
+    public ResponseEntity updateOrganizationAdoptionProcedure(@RequestBody AdoptionProcedure adoptionProcedureRequest, @PathVariable("id") String id) {
+        try {
+            organizationService.updateOrganizationAdoptionProcedure(adoptionProcedureRequest, id);
         } catch (Exception e) {
             logger.error(e.toString());
             return new ResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/furiends/backend/dto/AdoptionProcedure.java
+++ b/src/main/java/furiends/backend/dto/AdoptionProcedure.java
@@ -1,0 +1,16 @@
+package furiends.backend.dto;
+
+
+import java.util.List;
+
+public class AdoptionProcedure {
+    private List<AdoptionProcedureStep> steps;
+
+    public List<AdoptionProcedureStep> getSteps() {
+        return steps;
+    }
+
+    public void setSteps(List<AdoptionProcedureStep> steps) {
+        this.steps = steps;
+    }
+}

--- a/src/main/java/furiends/backend/dto/AdoptionProcedureStep.java
+++ b/src/main/java/furiends/backend/dto/AdoptionProcedureStep.java
@@ -1,0 +1,32 @@
+package furiends.backend.dto;
+
+
+public class AdoptionProcedureStep {
+    private int order;
+    private String title;
+    private String description;
+
+    public int getOrder() {
+        return order;
+    }
+
+    public void setOrder(int order) {
+        this.order = order;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/furiends/backend/model/Organization.java
+++ b/src/main/java/furiends/backend/model/Organization.java
@@ -34,6 +34,8 @@ public class Organization {
     private String welfare;
     private String wechatOfficialAccountId;
 
+    private String adoptionProcedure;
+
     public Organization() {
     }
 
@@ -231,6 +233,14 @@ public class Organization {
 
     public void setWechatOfficialAccountId(String wechatOfficialAccountId) {
         this.wechatOfficialAccountId = wechatOfficialAccountId;
+    }
+
+    public String getAdoptionProcedure() {
+        return adoptionProcedure;
+    }
+
+    public void setAdoptionProcedure(String adoptionProcedure) {
+        this.adoptionProcedure = adoptionProcedure;
     }
 }
 

--- a/src/main/java/furiends/backend/service/OrganizationService.java
+++ b/src/main/java/furiends/backend/service/OrganizationService.java
@@ -1,5 +1,7 @@
 package furiends.backend.service;
 
+import furiends.backend.dto.AdoptionProcedure;
+import furiends.backend.dto.AdoptionProcedureStep;
 import furiends.backend.dto.OrganizationRequest;
 import furiends.backend.model.Organization;
 import furiends.backend.repository.OrganizationRepository;
@@ -28,24 +30,39 @@ public class OrganizationService {
         return organizationRepository.findById(id);
     }
 
-    public Organization createOrganization(OrganizationRequest organizationRequest) {
+    public void createOrganization(OrganizationRequest organizationRequest) {
         Organization newOrganization = new Organization();
         newOrganization.setId();
         newOrganization.setCreatedTime();
         organizationTransformer.fromOrganizationRequestToOrganization(organizationRequest, newOrganization);
-        return organizationRepository.save(newOrganization);
+        organizationRepository.save(newOrganization);
     }
 
-    public Organization updateOrganization(OrganizationRequest organizationRequest, String id) {
+    public void updateOrganization(OrganizationRequest organizationRequest, String id) {
         Organization organizationInstance = findOrganizationById(id).get();
         organizationTransformer.fromOrganizationRequestToOrganization(organizationRequest, organizationInstance);
-        return organizationRepository.save(organizationInstance);
+        organizationRepository.save(organizationInstance);
     }
 
     public void deleteOrganization(String id) {
         if (organizationRepository.existsById(id)) {
             organizationRepository.deleteById(id);
         }
+    }
+
+    public List<AdoptionProcedureStep> listAdoptionProcedureSteps(String organizationId) {
+        Organization organization = findOrganizationById(organizationId).get();
+        String adoptionProcedureString = organization.getAdoptionProcedure();
+        List<AdoptionProcedureStep> adoptionProcedureStepList = organizationTransformer.fromJsonStringToAdoptionProcedureStepList(adoptionProcedureString);
+        return adoptionProcedureStepList;
+    }
+
+    public void updateOrganizationAdoptionProcedure(AdoptionProcedure adoptionProcedureRequest, String organizationId) {
+        Organization organization = findOrganizationById(organizationId).get();
+        if (organization == null) return;
+        String adoptionProcedureString = organizationTransformer.fromAdoptionProcedureToJsonString(adoptionProcedureRequest);
+        organization.setAdoptionProcedure(adoptionProcedureString);
+        organizationRepository.save(organization);
     }
 }
 

--- a/src/main/java/furiends/backend/transformer/OrganizationTransformer.java
+++ b/src/main/java/furiends/backend/transformer/OrganizationTransformer.java
@@ -1,8 +1,16 @@
 package furiends.backend.transformer;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import furiends.backend.dto.AdoptionProcedure;
+import furiends.backend.dto.AdoptionProcedureStep;
 import furiends.backend.dto.OrganizationRequest;
 import furiends.backend.model.Organization;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Component
 public class OrganizationTransformer {
@@ -28,5 +36,33 @@ public class OrganizationTransformer {
         newOrganization.setPostPlacementVisitCounts(organizationRequest.getPostPlacementVisitCounts());
         newOrganization.setWelfare(organizationRequest.getWelfare());
         newOrganization.setWechatOfficialAccountId(organizationRequest.getWechatOfficialAccountId());
+    }
+
+    public List<AdoptionProcedureStep> fromJsonStringToAdoptionProcedureStepList(String adoptionProcedureString) {
+        List<AdoptionProcedureStep> adoptionProcedureStepList = new ArrayList<>();
+        if (adoptionProcedureString == null || adoptionProcedureString.length() == 0) return adoptionProcedureStepList;
+        AdoptionProcedure adoptionProcedureInstance;
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            adoptionProcedureInstance = mapper.readValue(adoptionProcedureString, new TypeReference<>() {
+            });
+            adoptionProcedureStepList = adoptionProcedureInstance.getSteps();
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return adoptionProcedureStepList;
+    }
+
+    public String fromAdoptionProcedureToJsonString(AdoptionProcedure adoptionProcedure) {
+        if (adoptionProcedure == null) return "";
+        String adoptionProcedureString = "";
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            adoptionProcedureString = mapper.writeValueAsString(adoptionProcedure);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return adoptionProcedureString;
     }
 }


### PR DESCRIPTION
Implement adoption procedure related services and APIs under organization：
1. **POST organizations/{id}/adoptionProcedure** :  update adoption procedure list by organization id (create and delete operations can also use this API to update)
example: 
<img width="889" alt="PostAdoptionProcedure" src="https://user-images.githubusercontent.com/29030361/190508201-6be4686b-bc96-492b-bf4a-d0c8bdc2b2a4.png">

2. **GET organizations/{id}/adoptionProcedure**: get the adoption procedure list by organization id:
example:
<img width="891" alt="getAdoptionProcedure" src="https://user-images.githubusercontent.com/29030361/190507370-a91ab039-c967-435d-aaef-66a8585143eb.png">


3. **GET organizations/{id} : adoption procedure saved as JSON string in organization entity:
<img width="1174" alt="getOrg" src="https://user-images.githubusercontent.com/29030361/190508725-5341f095-1ab4-41c4-9ab6-bb755a4e24e1.png">
